### PR TITLE
Pin jupyter-book at 0.13.1

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -6,4 +6,4 @@ dependencies:
   - jinja2=3.0.3
   - pip=20
   - pip:
-    - jupyter-book
+    - jupyter-book==0.13.1


### PR DESCRIPTION
Figure we really should pin the environment to a known working version.