### PR TITLE
Switch to conda version of jupyter-book

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,9 +1,8 @@
 name: hpc2-jb
 channels:
   - defaults
+  - conda-forge
 dependencies:
   - python=3.9
   - jinja2=3.0.3
-  - pip=20
-  - pip:
-    - jupyter-book==0.13.1
+  - jupyter-book==0.15.1


### PR DESCRIPTION
The pip install of jupyter-book has been thrashing around to install on my desktop, and I'm now hitting the same problem in GH actions.

I suggest we fix this now, before my new changes, to use the conda release of jupyter-book, which is much faster and more reliable to install.