### PR TITLE
Correct branch reference in config

### DIFF
--- a/book/_config.yml
+++ b/book/_config.yml
@@ -29,4 +29,4 @@ launch_buttons:
 repository:
   url                       : https://github.com/ARCTraining/hpc2-software  # The URL to your book's repository
   path_to_book              : "book/"  # A path to your book's folder, relative to the repository root.
-  branch                    : gh-pages  # Which branch of the repository should be used when creating links
+  branch                    : main  # Which branch of the repository should be used when creating links


### PR DESCRIPTION
Same mistake as was made in another repo.  It references gh-pages, when it should reference the source repo.

Right now, if you click suggest edit, it takes you to the gh-pages branch, and generates a 404.