### PR TITLE
Correct rendering of references on Spack Environments page

### DIFF
--- a/book/course/spack/environments.md
+++ b/book/course/spack/environments.md
@@ -81,5 +81,5 @@ spack env deactivate
 
 ## References
 
-[Using Spack to Replace Homebrew/Conda](https://spack.readthedocs.io/en/latest/replace_conda_homebrew.html)
-[Environments](https://spack.readthedocs.io/en/latest/environments.html)
+- [Using Spack to Replace Homebrew/Conda](https://spack.readthedocs.io/en/latest/replace_conda_homebrew.html)
+- [Environments](https://spack.readthedocs.io/en/latest/environments.html)


### PR DESCRIPTION
This should have been a list, and wasn't, so now is.